### PR TITLE
Make useSubscription return only the subscribed topic

### DIFF
--- a/lib/Connector.tsx
+++ b/lib/Connector.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState, useCallback, useRef } from 'react';
 import { connect, MqttClient, IClientOptions } from 'mqtt';
 
 import MqttContext from './Context';
-import { IMessage, Error } from './types';
+import { Error } from './types';
 
 interface Props {
   brokerUrl?: string | object;
@@ -21,7 +21,6 @@ export default function Connector({
   const mountedRef = useRef(true);
   const [connectionStatus, setStatus] = useState<string | Error>('Offline');
   const [client, setClient] = useState<MqttClient | null>(null);
-  const [message, setMessage] = useState<IMessage>();
 
   const mqttConnect = useCallback(async () => {
     try {
@@ -60,15 +59,7 @@ export default function Connector({
   }, [brokerUrl, options]);
 
   useEffect(() => {
-    if (client) {
-      client.on('message', (topic, msg) => {
-        const payload = {
-          topic,
-          message: parserMethod?.(msg) || msg.toString(),
-        };
-        setMessage(payload);
-      });
-    } else {
+    if (!client) {
       mqttConnect();
     }
 
@@ -79,7 +70,7 @@ export default function Connector({
   }, [client, mqttConnect, parserMethod]);
 
   return (
-    <MqttContext.Provider value={{ connectionStatus, client, message }}>
+    <MqttContext.Provider value={{ connectionStatus, client, parserMethod }}>
       {children}
     </MqttContext.Provider>
   );

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -9,7 +9,7 @@ export interface Error {
 export interface IMqttContext {
   connectionStatus: string | Error;
   client?: MqttClient | null;
-  message?: IMessage;
+  parserMethod?: (message: any) => string;
 }
 
 export interface IUseSubscription {

--- a/lib/useMqttState.tsx
+++ b/lib/useMqttState.tsx
@@ -4,13 +4,13 @@ import MqttContext from './Context';
 import { IMqttContext as Context } from './types';
 
 export default function useMqttState() {
-  const { connectionStatus, client, message } = useContext<Context>(
+  const { connectionStatus, client, parserMethod } = useContext<Context>(
     MqttContext,
   );
 
   return {
     connectionStatus,
     client,
-    message,
+    parserMethod,
   };
 }

--- a/lib/useSubscription.tsx
+++ b/lib/useSubscription.tsx
@@ -9,7 +9,7 @@ export default function useSubscription(
   topic: string | string[],
   options: IClientSubscribeOptions = {} as IClientSubscribeOptions,
 ): IUseSubscription {
-  const { client, connectionStatus } = useContext<Context>(
+  const { client, connectionStatus, parserMethod } = useContext<Context>(
     MqttContext,
   );
   
@@ -25,7 +25,7 @@ export default function useSubscription(
       
       const callback = (receivedTopic, message) => {
         if (receivedTopic === topic) {
-          setMessage({topic, message: message.toString()})
+          setMessage({topic, message: parserMethod?.(msg) || msg.toString()})
         }
       };
       

--- a/lib/useSubscription.tsx
+++ b/lib/useSubscription.tsx
@@ -25,7 +25,7 @@ export default function useSubscription(
       
       const callback = (receivedTopic, message) => {
         if ([topic].flat().includes(receivedTopic)) {
-          setMessage({topic, message: parserMethod?.(message) || message.toString()})
+          setMessage({receivedTopic, message: parserMethod?.(message) || message.toString()})
         }
       };
       

--- a/lib/useSubscription.tsx
+++ b/lib/useSubscription.tsx
@@ -33,7 +33,7 @@ export default function useSubscription(
       
       return () => client.off(callback)
     }
-    return null
+    return
   }, [client, subscribe]);
 
   return {

--- a/lib/useSubscription.tsx
+++ b/lib/useSubscription.tsx
@@ -25,7 +25,7 @@ export default function useSubscription(
       
       const callback = (receivedTopic :string, message) => {
         if ([topic].flat().includes(receivedTopic)) {
-          setMessage({receivedTopic, message: parserMethod?.(message) || message.toString()})
+          setMessage({topic: receivedTopic, message: parserMethod?.(message) || message.toString()})
         }
       };
       

--- a/lib/useSubscription.tsx
+++ b/lib/useSubscription.tsx
@@ -13,7 +13,7 @@ export default function useSubscription(
     MqttContext,
   );
   
-  const [message, setMessage] = useState<IMessage | null>(null)
+  const [message, setMessage] = useState<IMessage | undefined>(undefined)
  
   const subscribe = useCallback(async () => {
     client?.subscribe(topic, options);    
@@ -24,8 +24,8 @@ export default function useSubscription(
       subscribe();
       
       const callback = (receivedTopic, message) => {
-        if (receivedTopic === topic) {
-          setMessage({topic, message: parserMethod?.(msg) || msg.toString()})
+        if ([topic].flat().includes(receivedTopic)) {
+          setMessage({topic, message: parserMethod?.(message) || message.toString()})
         }
       };
       
@@ -33,6 +33,7 @@ export default function useSubscription(
       
       return () => client.off(callback)
     }
+    return null
   }, [client, subscribe]);
 
   return {

--- a/lib/useSubscription.tsx
+++ b/lib/useSubscription.tsx
@@ -1,5 +1,5 @@
 import { useContext, useEffect, useCallback, useState } from 'react';
-import { matches } from 'mqtt-pattern';
+import { matche } from 'mqtt-pattern';
 
 import { IClientSubscribeOptions } from 'mqtt';
 
@@ -25,7 +25,7 @@ export default function useSubscription(
       subscribe();
       
       const callback = (receivedTopic :string, message) => {
-        if ([topic].flat().some(receivedTopic => matches(topic, receivedTopic))) {
+        if ([topic].flat().some(receivedTopic => matche(topic, receivedTopic))) {
           setMessage({topic: receivedTopic, message: parserMethod?.(message) || message.toString()})
         }
       };

--- a/lib/useSubscription.tsx
+++ b/lib/useSubscription.tsx
@@ -9,17 +9,29 @@ export default function useSubscription(
   topic: string | string[],
   options: IClientSubscribeOptions = {} as IClientSubscribeOptions,
 ): IUseSubscription {
-  const { client, connectionStatus, message } = useContext<Context>(
+  const { client, connectionStatus } = useContext<Context>(
     MqttContext,
   );
-
+  
+  const [message, setMessage] = useState()
+ 
   const subscribe = useCallback(async () => {
-    client?.subscribe(topic, options);
+    client?.subscribe(topic, options);    
   }, [client, options, topic]);
 
   useEffect(() => {
     if (client?.connected) {
       subscribe();
+      
+      const callback = (receivedTopic, message) => {
+        if (receivedTopic === topic) {
+          setMessage({topic, message: message.toString()})
+        }
+      };
+      
+      client.on('message', callback);
+      
+      return () => client.off(callback)
     }
   }, [client, subscribe]);
 

--- a/lib/useSubscription.tsx
+++ b/lib/useSubscription.tsx
@@ -1,5 +1,5 @@
 import { useContext, useEffect, useCallback, useState } from 'react';
-import { matche } from 'mqtt-pattern';
+import { matches } from 'mqtt-pattern';
 
 import { IClientSubscribeOptions } from 'mqtt';
 
@@ -25,7 +25,7 @@ export default function useSubscription(
       subscribe();
       
       const callback = (receivedTopic :string, message) => {
-        if ([topic].flat().some(receivedTopic => matche(topic, receivedTopic))) {
+        if ([topic].flat().some(receivedTopic => matches(topic, receivedTopic))) {
           setMessage({topic: receivedTopic, message: parserMethod?.(message) || message.toString()})
         }
       };

--- a/lib/useSubscription.tsx
+++ b/lib/useSubscription.tsx
@@ -3,7 +3,7 @@ import { useContext, useEffect, useCallback } from 'react';
 import { IClientSubscribeOptions } from 'mqtt';
 
 import MqttContext from './Context';
-import { IMqttContext as Context, IUseSubscription } from './types';
+import { IMqttContext as Context, IUseSubscription, IMessage } from './types';
 
 export default function useSubscription(
   topic: string | string[],
@@ -13,7 +13,7 @@ export default function useSubscription(
     MqttContext,
   );
   
-  const [message, setMessage] = useState()
+  const [message, setMessage] = useState<IMessage | null>(null)
  
   const subscribe = useCallback(async () => {
     client?.subscribe(topic, options);    

--- a/lib/useSubscription.tsx
+++ b/lib/useSubscription.tsx
@@ -31,7 +31,7 @@ export default function useSubscription(
       
       client.on('message', callback);
       
-      return () => client.off(callback)
+      return () => client.off('message', callback)
     }
     return
   }, [client, subscribe]);

--- a/lib/useSubscription.tsx
+++ b/lib/useSubscription.tsx
@@ -23,7 +23,7 @@ export default function useSubscription(
     if (client?.connected) {
       subscribe();
       
-      const callback = (receivedTopic, message) => {
+      const callback = (receivedTopic :string, message) => {
         if ([topic].flat().includes(receivedTopic)) {
           setMessage({receivedTopic, message: parserMethod?.(message) || message.toString()})
         }

--- a/lib/useSubscription.tsx
+++ b/lib/useSubscription.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useCallback } from 'react';
+import { useContext, useEffect, useCallback, useState } from 'react';
 
 import { IClientSubscribeOptions } from 'mqtt';
 

--- a/lib/useSubscription.tsx
+++ b/lib/useSubscription.tsx
@@ -25,7 +25,7 @@ export default function useSubscription(
       subscribe();
       
       const callback = (receivedTopic :string, message) => {
-        if ([topic].flat().any(receivedTopic => matches(topic, receivedTopic))) {
+        if ([topic].flat().some(receivedTopic => matches(topic, receivedTopic))) {
           setMessage({topic: receivedTopic, message: parserMethod?.(message) || message.toString()})
         }
       };

--- a/lib/useSubscription.tsx
+++ b/lib/useSubscription.tsx
@@ -1,4 +1,5 @@
 import { useContext, useEffect, useCallback, useState } from 'react';
+import { matches } from 'mqtt-pattern';
 
 import { IClientSubscribeOptions } from 'mqtt';
 
@@ -24,7 +25,7 @@ export default function useSubscription(
       subscribe();
       
       const callback = (receivedTopic :string, message) => {
-        if ([topic].flat().includes(receivedTopic)) {
+        if ([topic].flat().any(receivedTopic => matches(topic, receivedTopic))) {
           setMessage({topic: receivedTopic, message: parserMethod?.(message) || message.toString()})
         }
       };


### PR DESCRIPTION
Fixes https://github.com/VictorHAS/mqtt-react-hooks/issues/13#issuecomment-769151746 / #14 - 1

This is a breaking change, message is not returned anymore from useMqttState

Use similar approach as apollo graphql useSubscription:

https://github.com/apollographql/apollo-client/blob/cbcf951256b22553bdb065dfa0d32c0a4ca804d3/src/react/hooks/useSubscription.ts

edit: can you merge all the commits into a single one?