### PR TITLE
fix mqtt dependency exactly to version 4.2.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "react-dom": ">= 16.8.0"
   },
   "dependencies": {
-    "mqtt": "^4.2.8",
+    "mqtt": "4.2.8",
     "mqtt-pattern": "^1.2.0"
   },
   "config": {


### PR DESCRIPTION
4.3.x introduces a bug that won't delete message in outgoing mqtt.Store if qos 1 is used
https://github.com/VictorHAS/mqtt-react-hooks/issues/44